### PR TITLE
build: release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.7
+      - name: Get tag
+        id: get-tag
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+      - name: Prepare
+        run: |
+          poetry version ${{ steps.get-tag.outputs.tag }}
+          poetry build
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get-tag.outputs.tag }}
+          draft: true
+          files: ./dist/*
+
+
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CICD](https://github.com/mcataford/slack-status-cli/actions/workflows/main.yml/badge.svg)](https://github.com/mcataford/slack-status-cli/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/mcataford/slack-status-cli/branch/main/graph/badge.svg?token=10VP1ZDBHR)](https://codecov.io/gh/mcataford/slack-status-cli)
 [![python-support](https://img.shields.io/badge/python-%5E3.7-brightgreen)]()
+[![latest-release](https://img.shields.io/github/v/release/mcataford/slack-status-cli?include_prereleases&label=latest%20release&sort=semver)]()
 
 ## Overview
 
@@ -36,4 +37,5 @@ and/or CLI args will override these defaults if given).
 ## Installation
 
 You can clone this repository and build from source. This project uses `poetry`, as such `poetry build` will prepare a
-Wheel that you can install directly.
+Wheel that you can install directly. Build artifacts for released versions are also available under
+[releases](https://github.com/mcataford/slack-status-cli/releases).


### PR DESCRIPTION
- Adds tag-based release flow. Create a new tag to trigger a release.
- Mentions release artifact availability in docs.