### PR TITLE
fix: use the correct tag for release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           poetry build
       - uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.get-tag.outputs.tag }}
+          tag_name: ${{ join(['v', steps.get-tag.outputs.tag]) }}
           draft: true
           files: ./dist/*
 


### PR DESCRIPTION
- Fixes typo in release flow that would recreate a tag (non-prefixed) on release.